### PR TITLE
Support more item groups in recipes

### DIFF
--- a/mods/main/items.lua
+++ b/mods/main/items.lua
@@ -9,16 +9,19 @@ minetest.register_craftitem("main:apple", {
 minetest.register_craftitem("main:stick", {
 	description = "Stick",
 	inventory_image = "stick.png",
+	groups = {stick = 1}
 })
 
 minetest.register_craftitem("main:coal", {
 	description = "Coal",
 	inventory_image = "coal.png",
+	groups = {coal = 1}
 })
 
 minetest.register_craftitem("main:charcoal", {
 	description = "Charcoal",
 	inventory_image = "charcoal.png",
+	groups = {coal = 1}
 })
 
 minetest.register_craftitem("main:iron", {

--- a/mods/redstone/button.lua
+++ b/mods/redstone/button.lua
@@ -16,7 +16,7 @@ end
 
 
 minetest.register_node("redstone:button_off", {
-    description = "Crafting Table",
+    description = "Button",
     tiles = {"stone.png"},
     groups = {stone = 1, hard = 1, pickaxe = 1, hand = 4,attached_node = 1,dig_immediate=1},
     sounds = main.stoneSound(),
@@ -56,7 +56,7 @@ minetest.register_node("redstone:button_off", {
 	on_destruct = on_button_destroy,
 })
 minetest.register_node("redstone:button_on", {
-    description = "Crafting Table",
+    description = "Button",
     tiles = {"stone.png"},
     groups = {stone = 1, hard = 1, pickaxe = 1, hand = 4,attached_node = 1,dig_immediate=1},
     sounds = main.stoneSound(),

--- a/mods/too_many_items/init.lua
+++ b/mods/too_many_items/init.lua
@@ -97,14 +97,26 @@ local recipe_converter = function (items, width)
 
     return(usable_recipe)
 end
+
+local map_group_to_item = {
+	["coal"]  = "main:coal",
+	["glass"] = "main:glass",
+	["sand"]  = "main:sand",
+	["stick"] = "main:stick",
+	["stone"] = "main:cobble",
+	["tree"]  = "main:tree",
+	["wood"]  = "main:wood"
+}
+
 get_if_group = function(item)
-	 if item == "group:stone" then
-		return("main:cobble")
-	elseif item == "group:wood" then
-		return("main:wood")
-	else
-		return(item)
+	if item ~= nil and item:sub(1,6) == "group:" then
+		local group_name = item:sub(7, item:len())
+		local mapped_item = map_group_to_item[group_name]
+		if mapped_item ~= nil then
+			return(mapped_item)
+		end
 	end
+	return(item)
 end
 	
 

--- a/mods/torch/init.lua
+++ b/mods/torch/init.lua
@@ -171,14 +171,7 @@ minetest.register_node("torch:wall", {
 minetest.register_craft({
 	output = "torch:torch 4",
 	recipe = {
-		{"main:coal"},
-		{"main:stick"}
-	}
-})
-minetest.register_craft({
-	output = "torch:torch 4",
-	recipe = {
-		{"main:charcoal"},
-		{"main:stick"}
+		{"group:coal"},
+		{"group:stick"}
 	}
 })


### PR DESCRIPTION
@oilboi  I totally understand if you're not interested in pull requests at this stage.

The purpose of this PR is just to get the groups working in craft items, to allow game-agnostic minetest mods to add simple recipes. 

If that sounds daft, it was really because I'm trying to make one of *my* mods game-agnostic enough to work in Crafter, and it had a recipe involving sticks :)

Anyway, **heads up on a potential problem** (which you may already be aware of)...

I saw there was already some support for using groups in recipes, and that groups like stone and wood have become overloaded - a node being in "wood" group meant it can be used in recipes which call for "group:wood", but it's also used to specify the node's material properties for tools and punching etc.

Seems like something that would be easier to fix early on, unless it's a design decision there'll be nodes where the material group doesn't match which recipes it's intended for.