### PR TITLE
Even snow coverage, eventually covering ground in full blanket

### DIFF
--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -25,12 +25,12 @@ update_player_sky = function()
 				base_color="#808080",
 				type="plain",
 				clouds=false,
-				
+
 				day_sky = "#808080",
 				dawn_horizon = "#808080",
 				dawn_sky = "#808080",
 				fog_sun_tint = "#808080",
-				
+
 				night_sky="#808080",
 				night_horizon="#808080"
 			})
@@ -42,16 +42,16 @@ update_player_sky = function()
 				base_color="#8cbafa",
 				type="regular",
 				clouds=true,
-				
+
 				day_sky = "#8cbafa",
-				
+
 				dawn_horizon = "#bac1f0",
 				dawn_sky = "#b4bafa",
-				
+
 				night_sky="#006aff",
 				night_horizon="#4090ff"
 			})
-			
+
 			player:set_sun({visible=true,sunrise_visible=true})
 			player:set_moon({visible=true})
 			player:set_stars({visible=true})
@@ -71,7 +71,7 @@ minetest.register_on_mods_loaded(function()
 		if name ~= "air" and name ~= "ignore" then
 			table.insert(all_nodes,name)
 		end
-	end	
+	end
 end)
 
 --this sends the client all nodes that weather can be on top of
@@ -102,22 +102,27 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 --spawn snow nodes
+local cDoSnow_call_count_for_blanket_coverage  = 50 -- how many calls of do_snow() are required for blanket snow coverage
+local cDoSnow_call_count_for_snowState_catchup = 20 -- how many calls of do_snow() (at most) before weather_snowState will catch up to the pattern on the ground (e.g. if player went somewhere else while it was snowing then came back)
+local cSnowState_LFSR_taps, cSnowState_LFSR_length = 0x100D, 8191 -- Fizzlefade constants for the shortest maximum length LFSR that can cover an 80 x 80 area (i.e. has a length larger than 6400)
+local cSnow_length_x = 80 -- (cSnow_length_x * cSnow_length_z) MUST be less than cSnowState_LFSR_length
+local cSnow_length_y = 80
+local cSnow_length_z = 80 -- (cSnow_length_x * cSnow_length_z) MUST be less than cSnowState_LFSR_length
+local snow_area = vector.new(cSnow_length_x, cSnow_length_y, cSnow_length_z)
+local snow_radius = vector.divide(snow_area, 2)
 local pos
-local area = vector.new(80,40,80)
 local min
 local max
 local subber = vector.subtract
 local adder  = vector.add
 local area_index
 local under_air = minetest.find_nodes_in_area_under_air
-local area
 local round_it = vector.round
-local randomize_number = math.random
 local n_vec = vector.new
 local lightlevel
 local get_light = minetest.get_node_light
 local g_node = minetest.get_node
-local node
+local node_name
 local def
 local buildable
 local walkable
@@ -129,38 +134,95 @@ local spawn_table
 local mass_set = minetest.bulk_set_node
 local inserter = table.insert
 local temp_pos
-local get_table_size = table.getn
+local floor, ceil = math.floor, math.ceil
+local weather_snowState
+local snowState_iterations_per_call  = ceil(cSnowState_LFSR_length / cDoSnow_call_count_for_blanket_coverage)
+local snowState_max_catchup_per_call = ceil(cSnowState_LFSR_length / cDoSnow_call_count_for_snowState_catchup)
+local under_air_iterations
+local catchup_steps
+local lsfr_steps_count
+local lsb
+local location_bits
+local relative_x
+local relative_z
+local under_air_count
+local x, y, z
 
 --this is debug
 --local average = {}
+
+function XOR( num1, num2 )
+	-- This XOR function is excerpted from the Bitwise Operations Mod v1.2, by Leslie E. Krause
+	-- which is provided under the MIT License (MIT)
+	--
+	-- The MIT License (MIT)
+	--
+	-- Copyright (c) 2020, Leslie Krause (leslie@searstower.org)
+	--
+	-- Permission is hereby granted, free of charge, to any person obtaining a copy of this
+	-- software and associated documentation files (the "Software"), to deal in the Software
+	-- without restriction, including without limitation the rights to use, copy, modify, merge,
+	-- publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+	-- persons to whom the Software is furnished to do so, subject to the following conditions:
+	--
+	-- The above copyright notice and this permission notice shall be included in all copies or
+	-- substantial portions of the Software.
+	--
+	-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+	-- INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+	-- PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+	-- FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+	-- OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+	-- DEALINGS IN THE SOFTWARE.
+	--
+	-- For more details:
+	-- https://opensource.org/licenses/MIT
+
+	local exp = 1
+	local res = 0
+	while num1 > 0 or num2 > 0 do
+		local rem1 = num1 % 2
+		local rem2 = num2 % 2
+		if rem1 ~= rem2 then
+			-- set each bit
+			res = res + exp
+		end
+		num1 = ( num1 - rem1 ) / 2
+		num2 = ( num2 - rem2 ) / 2
+		exp = exp * 2
+	end
+	return res
+end
+
 
 local function do_snow()
 	if weather_type == 1 then
 		for _,player in ipairs(minetest.get_connected_players()) do
 			--this is debug
 			--local t0 = os.clock()
-			
+
 			pos = round_it(player:get_pos())
-			
-			area = n_vec(40,40,40)
-			min = subber(pos, area)
-			max = adder(pos, area)
-			
+			min = subber(pos, snow_radius)
+			max = adder(pos, snow_radius)
+
 			area_index = under_air(min, max, all_nodes)
-			
+			--local node_search_time = math.ceil((os.clock() - t0) * 1000)
+
 			spawn_table = {}
-			
-			--the highest value is always indexed last in minetest.find_nodes_in_area_under_air, 
+
+			--the highest value is always indexed last in minetest.find_nodes_in_area_under_air,
 			--so all that is needed is to iterate through it backwards and hook into the first
 			--y value on the x and y and ignore the rest
-			for key = get_table_size(area_index),1,-1 do
+			under_air_count = 0
+			for key = #area_index,1,-1 do
 				temp_pos = area_index[key]
 				if not spawn_table[temp_pos.x] then spawn_table[temp_pos.x] = {} end
 				if not spawn_table[temp_pos.x][temp_pos.z] then
 					spawn_table[temp_pos.x][temp_pos.z] = temp_pos.y
+					under_air_count = under_air_count + 1
 				end
 			end
-			
+
 			--save old method just in case useful or turns out it's faster after all
 			--for _,index in pairs(area_index) do
 			--	if not spawn_table[index.x] then spawn_table[index.x] = {} end
@@ -170,48 +232,88 @@ local function do_snow()
 			--		spawn_table[index.x][index.z] = index.y
 			--	end
 			--end
-			
-			--find the highest y value
-			bulk_list = {}
-			ice_list = {}
-			for x,x_index in pairs(spawn_table) do
-				for z,y in pairs(x_index) do
-					if randomize_number(1100) >= 1098 then
-						lightlevel = get_light(n_vec(x,y+1,z), 0.5)
-						if lightlevel >= 14 then
-							--make it so buildable to nodes get replaced
-							node = g_node(n_vec(x,y,z)).name
-							def = r_nodes[node]
-							buildable = def.buildable_to
-							walkable = def.walkable
-							liquid = (def.liquidtype ~= "none")
-							
-							if not liquid then
-								if not buildable and g_node(n_vec(x,y+1,z)).name ~= "weather:snow" and walkable == true then
-									inserter(bulk_list, n_vec(x,y+1,z))
-								elseif buildable == true and node ~= "weather:snow" then
-									inserter(bulk_list, n_vec(x,y,z))
+
+			bulk_list            = {}
+			ice_list             = {}
+			under_air_iterations = 0
+			catchup_steps        = 0
+			lsfr_steps_count     = 0
+			repeat
+				-- "fizzelfade" in the snow with a Linear Feedback Shift Register (LFSR)
+				-- https://fabiensanglard.net/fizzlefade/index.php
+				lsb = weather_snowState % 2 -- Get the output bit.
+				weather_snowState = floor(weather_snowState / 2) -- Shift register
+				if lsb == 1 then
+					weather_snowState = XOR(weather_snowState, cSnowState_LFSR_taps)
+				end
+				lsfr_steps_count = lsfr_steps_count + 1
+
+				location_bits = weather_snowState - 1 -- LFSR values start at 1, but we want snow to be able to fall on (0, 0)
+				relative_x = location_bits % cSnow_length_x
+				relative_z = floor(location_bits / cSnow_length_x)
+
+				if relative_z < cSnow_length_z then
+					x = (floor(min.x / cSnow_length_x) * cSnow_length_x) + relative_x -- align fizzelfade coords world-global
+					if x < min.x then x = x + cSnow_length_x end -- ensure it falls in the same space as area_index
+					local x_index = spawn_table[x]
+					if x_index ~= nil then
+						z = (floor(min.z / cSnow_length_z) * cSnow_length_z) + relative_z -- align fizzelfade coords world-global
+						if z < min.z then z = z + cSnow_length_z end -- ensure it falls in the same space as area_index
+						y = x_index[z]
+						if y ~= nil then
+
+							-- We hit a location that's in the spawn_table
+							under_air_iterations = under_air_iterations + 1
+
+							lightlevel = get_light(n_vec(x,y+1,z), 0.5)
+							if lightlevel >= 14 then
+								-- daylight is above or near this node, so snow can fall on it
+
+								--make it so buildable to nodes get replaced
+								node_name = g_node(n_vec(x,y,z)).name
+								def = r_nodes[node_name]
+								buildable = def.buildable_to
+								walkable = def.walkable
+								liquid = (def.liquidtype ~= "none")
+
+								if not liquid then
+									if buildable then
+										if node_name ~= "weather:snow" then
+											inserter(bulk_list, n_vec(x,y,z))
+										else
+											catchup_steps = catchup_steps + 1 -- we've already snowed on this spot
+										end
+									elseif walkable then
+										if g_node(n_vec(x,y+1,z)).name ~= "weather:snow" then
+											inserter(bulk_list, n_vec(x,y+1,z))
+										else
+											catchup_steps = catchup_steps + 1 -- we've already snowed on this spot
+										end
+									end
+								elseif node_name == "main:water" then
+									inserter(ice_list, n_vec(x,y,z))
 								end
-							elseif g_node(n_vec(x,y,z)).name == "main:water" then
-								inserter(ice_list, n_vec(x,y,z))
 							end
+
 						end
 					end
 				end
-			end
+			until (lsfr_steps_count - catchup_steps) >= snowState_iterations_per_call or catchup_steps >= snowState_max_catchup_per_call
+
 			if bulk_list then
 				mass_set(bulk_list, {name="weather:snow"})
 			end
 			if ice_list then
 				mass_set(ice_list, {name="main:ice"})
 			end
-			
-			
+
+
 			--this is debug
 			--[[
 			local chugent = math.ceil((os.clock() - t0) * 1000)
 			print("---------------------------------")
-			print ("Snow generation time " .. chugent .. " ms")
+			print("find_nodes_in_area_under_air() time: " .. node_search_time .. " ms")
+			print("New Snow generation time:            " .. chugent .. " ms  [" .. (chugent - node_search_time) .. " ms]")
 
 			inserter(average, chugent)
 			local a = 0
@@ -225,11 +327,12 @@ local function do_snow()
 			print(dump(average))
 			a = a / get_table_size(average)
 			print("average = "..a.."ms")
-			print("---------------------------------")
-			]]--
+			minetest.chat_send_all("total nodes under air: " .. under_air_count .. ", LFSR iterations: " .. lsfr_steps_count .. ", under-air hits (nodes tested): " .. under_air_iterations .. "        Snow added: " .. (#bulk_list + #ice_list)  .. ", snow already there (catchup): " .. catchup_steps)
+			--print("---------------------------------")
+			--]]--
 		end
 	end
-	
+
 	minetest.after(3, function()
 		do_snow()
 	end)
@@ -267,12 +370,16 @@ minetest.register_on_mods_loaded(function()
 		weather_type = math.random(0,weather_max)
 		mod_storage:set_int("weather_type", weather_type)
 	end
+
+	weather_snowState = math.max(mod_storage:get_int("weather_snowState"), 1)
+
 	randomize_weather()
 	end)
 end)
 
 minetest.register_on_shutdown(function()
 	mod_storage:set_int("weather_type", weather_type)
+	mod_storage:set_int("weather_snowState", weather_snowState)
 end)
 
 local snowball_throw = function(player)
@@ -421,11 +528,11 @@ snowball.on_step = function(self, dtime)
 	local vel = self.object:get_velocity()
 	local hit = false
 	local pos = self.object:get_pos()
-	
+
 	--hit object with the snowball
 	for _,object in ipairs(minetest.get_objects_inside_radius(pos, 1)) do
 		if (object:is_player() and object:get_hp() > 0 and object:get_player_name() ~= self.thrower) or (object:get_luaentity() and object:get_luaentity().mob == true and object ~= self.owner) then
-			object:punch(self.object, 2, 
+			object:punch(self.object, 2,
 				{
 				full_punch_interval=1.5,
 				damage_groups = {damage=0,fleshy=0},
@@ -434,7 +541,7 @@ snowball.on_step = function(self, dtime)
 			break
 		end
 	end
-	
+
 	if (self.oldvel and ((vel.x == 0 and self.oldvel.x ~= 0) or (vel.y == 0 and self.oldvel.y ~= 0) or (vel.z == 0 and self.oldvel.z ~= 0))) or hit == true then
 		--snowballs explode in the nether
 		if pos.y <= -10000 and pos.y >= -20000 then
@@ -477,7 +584,7 @@ snowball.on_step = function(self, dtime)
 			self.object:remove()
 		end
 	end
-	
+
 	self.oldvel = vel
 end
 minetest.register_entity("weather:snowball", snowball)


### PR DESCRIPTION
[![image](https://user-images.githubusercontent.com/6390507/83329719-6f26d500-a2ce-11ea-9963-49bb9db1db4f.png)
Video of the snow from this PR](https://youtu.be/ugcTkbKZD_U?t=8s), with some timing info.

Uses "[fizzlefade](https://fabiensanglard.net/fizzlefade/index.php)" effect to ensure `do_snow()` first covers empty nodes before any snow falls on nodes which already have snow.

To adjust how many times `do_snow()` must be invoked for a full blanket of snow, adjust the value of `cDoSnow_call_count_for_blanket_coverage`. For the video it was set to 50, i.e. 2 mins 30 secs for a full blanket if `do_snow()` is invoked every 3 seconds

![Crafter snow](https://user-images.githubusercontent.com/6390507/83326827-557b9280-a2ba-11ea-9c7c-771ef2e1c32a.jpg)
Pristine!

The XOR() function can be removed and replaced with 4 hard-coded if statements inline, if you'd rather not have that excerpted function with licence. I went with XOR because it's easier for a reviewer to understand what's happening.

[That XOR call](https://github.com/oilboi/Crafter/blob/cb5830f85ccc177c444572fcb8bfd6e8b1f32301/mods/weather/init.lua#L246-L248) could be replaced with

```
if lsb == 1 then
	-- XOR weather_snowState with 0x100D
	if floor(weather_snowState / 0x1000) % 2 == 1 then weather_snowState = weather_snowState - 0x1000 else weather_snowState = weather_snowState + 0x1000 end -- tap 13
	if floor(weather_snowState / 0x0008) % 2 == 1 then weather_snowState = weather_snowState - 0x0008 else weather_snowState = weather_snowState + 0x0008 end -- tap 4
	if floor(weather_snowState / 0x0004) % 2 == 1 then weather_snowState = weather_snowState - 0x0004 else weather_snowState = weather_snowState + 0x0004 end -- tap 3
	if weather_snowState % 2 == 1 then weather_snowState = weather_snowState - 1 else weather_snowState = weather_snowState + 1 end                           -- tap 1
end
```


Also. a snow volume of 90×64×90 around the player (instead of 80×80×80) might be worth experimenting with - 90×90 is the largest square area you can get before needing to move up to a 14 bit fizzlefade, 90×64×90 keeps the `minetest.find_nodes_in_area_under_air()` search volume almost the same number of nodes, while extending the snow horizon by 10, e.g:
```
local cSnow_length_x = 90 -- (cSnow_length_x * cSnow_length_z) MUST be less than cSnowState_LFSR_length
local cSnow_length_y = 64
local cSnow_length_z = 90 -- (cSnow_length_x * cSnow_length_z) MUST be less than cSnowState_LFSR_length
```